### PR TITLE
Added NET_ADMIN capability to evpn bridge container

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Run `docker-compose up -d`
 ## Manual gRPC example
 
 ```bash
-docker-compose exec opi-evpn-bridge grpcurl -plaintext -d '{"interface":{"spec":{"id": {"value": "ok"}}}}' localhost:50151 opi_api.network.cloud.v1alpha1.CloudInfraService.CreateInterface
-docker-compose exec opi-evpn-bridge grpcurl -plaintext -d '{"subnet":{"spec":{"id": {"value": "ok"}}}}' localhost:50151 opi_api.network.cloud.v1alpha1.CloudInfraService.CreateSubnet
+docker-compose exec opi-evpn-bridge grpcurl -plaintext -d '{"interface":{"name": "testinterface"}}' localhost:50151 opi_api.network.cloud.v1alpha1.CloudInfraService.CreateInterface
+sudo docker-compose exec opi-evpn-bridge grpcurl -plaintext -d '{"subnet":{"name": "testbridge"}}' localhost:50151 opi_api.network.cloud.v1alpha1.CloudInfraService.CreateSubnet
 ```
 
 ## Architecture Diagram

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -344,6 +344,8 @@ services:
   opi-evpn-bridge:
     build:
       context: .
+    cap_add:
+      - NET_ADMIN
     depends_on:
       - leaf1
     network_mode: service:leaf1


### PR DESCRIPTION
NET_ADMIN capability is needed to avoid permission errors while executing read-write netlink commands. Adding this in opi-evpn-bridge since it shares the same network as leaf1. 