### PR TITLE
use full name instead of {resource}_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ Run `docker-compose up -d`
 ## Manual gRPC example
 
 ```bash
-docker-compose exec opi-evpn-bridge grpcurl -plaintext -d '{"interface":{"name": "testinterface"}}' localhost:50151 opi_api.network.cloud.v1alpha1.CloudInfraService.CreateInterface
-docker-compose exec opi-evpn-bridge grpcurl -plaintext -d '{"subnet":{"name": "testbridge"}}' localhost:50151 opi_api.network.cloud.v1alpha1.CloudInfraService.CreateSubnet
+docker-compose exec opi-evpn-bridge grpcurl -plaintext -d '{"interface" : {"spec" : {"ifid": 11} }, "interface_id" : "testinterface", "parent" : "todo" }' localhost:50151 opi_api.network.cloud.v1alpha1.CloudInfraService.CreateInterface
+docker-compose exec opi-evpn-bridge grpcurl -plaintext -d '{"subnet" : {"spec" : {"ipv4_virtual_router_ip": 44} }, "subnet_id" : "testbridge", "parent" : "todo" }' localhost:50151 opi_api.network.cloud.v1alpha1.CloudInfraService.CreateSubnet
+docker-compose exec opi-evpn-bridge grpcurl -plaintext -d '{"name": "//network.opiproject.org/vpc/testbridge"}' localhost:50151 opi_api.network.cloud.v1alpha1.CloudInfraService.DeleteSubnet
+docker-compose exec opi-evpn-bridge grpcurl -plaintext -d '{"name": "//network.opiproject.org/vpc/testinterface"}' localhost:50151 opi_api.network.cloud.v1alpha1.CloudInfraService.DeleteInterface
 ```
 
 ## Architecture Diagram

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,7 +30,10 @@ func main() {
 	s := grpc.NewServer()
 
 	// TODO: replace cloud -> evpn
-	pb.RegisterCloudInfraServiceServer(s, &server.Server{})
+	pb.RegisterCloudInfraServiceServer(s, &server.Server{
+		Subnets:    make(map[string]*pb.Subnet),
+		Interfaces: make(map[string]*pb.Interface),
+	})
 
 	reflection.Register(s)
 

--- a/pkg/evpn/evpn.go
+++ b/pkg/evpn/evpn.go
@@ -46,7 +46,7 @@ func (s *Server) CreateSubnet(_ context.Context, in *pb.CreateSubnetRequest) (*p
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.SubnetId, in.Subnet.Name)
 		resourceID = in.SubnetId
 	}
-	in.Subnet.Name = resourceID
+	in.Subnet.Name = fmt.Sprintf("//network.opiproject.org/vpc/%s", resourceID)
 	// idempotent API when called with same key, should return same object
 	snet, ok := s.Subnets[in.Subnet.Name]
 	if ok {
@@ -86,6 +86,7 @@ func (s *Server) CreateSubnet(_ context.Context, in *pb.CreateSubnetRequest) (*p
 	response := proto.Clone(in.Subnet).(*pb.Subnet)
 	response.Status = &pb.SubnetStatus{HwIndex: 8}
 	s.Subnets[in.Subnet.Name] = response
+	log.Printf("CreateSubnet: Sending to client: %v", response)
 	return response, nil
 }
 
@@ -150,7 +151,7 @@ func (s *Server) CreateInterface(_ context.Context, in *pb.CreateInterfaceReques
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.InterfaceId, in.Interface.Name)
 		resourceID = in.InterfaceId
 	}
-	in.Interface.Name = resourceID
+	in.Interface.Name = fmt.Sprintf("//network.opiproject.org/vpc/%s", resourceID)
 	// idempotent API when called with same key, should return same object
 	iface, ok := s.Interfaces[in.Interface.Name]
 	if ok {
@@ -188,6 +189,7 @@ func (s *Server) CreateInterface(_ context.Context, in *pb.CreateInterfaceReques
 	response := proto.Clone(in.Interface).(*pb.Interface)
 	response.Status = &pb.InterfaceStatus{IfIndex: 8}
 	s.Interfaces[in.Interface.Name] = response
+	log.Printf("CreateInterface: Sending to client: %v", response)
 	return response, nil
 }
 


### PR DESCRIPTION
- initialize the structures
- use full name instead of {resource}_id
