### PR TITLE
tests: use proto.Equal

### DIFF
--- a/pkg/evpn/interface_test.go
+++ b/pkg/evpn/interface_test.go
@@ -6,7 +6,6 @@
 package evpn
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -91,13 +90,8 @@ func Test_CreateInterface(t *testing.T) {
 
 			request := &pb.CreateInterfaceRequest{Interface: tt.in, InterfaceId: tt.id, Parent: "todo"}
 			response, err := client.CreateInterface(ctx, request)
-			if response != nil {
-				// if !reflect.DeepEqual(response, tt.out) {
-				mtt, _ := proto.Marshal(tt.out)
-				mResponse, _ := proto.Marshal(response)
-				if !bytes.Equal(mtt, mResponse) {
-					t.Error("response: expected", tt.out, "received", response)
-				}
+			if !proto.Equal(tt.out, response) {
+				t.Error("response: expected", tt.out, "received", response)
 			}
 
 			if er, ok := status.FromError(err); ok {
@@ -268,18 +262,8 @@ func Test_UpdateInterface(t *testing.T) {
 
 			request := &pb.UpdateInterfaceRequest{Interface: tt.in, UpdateMask: tt.mask}
 			response, err := client.UpdateInterface(ctx, request)
-			if response != nil {
-				// Marshall the request and response, so we can just compare the contained data
-				mtt, _ := proto.Marshal(tt.out.Spec)
-				mResponse, _ := proto.Marshal(response.Spec)
-
-				// Compare the marshalled messages
-				if !bytes.Equal(mtt, mResponse) {
-					t.Error("response: expected", tt.out.GetSpec(), "received", response.GetSpec())
-				}
-				if !reflect.DeepEqual(response.Status, tt.out.Status) {
-					t.Error("response: expected", tt.out.GetStatus(), "received", response.GetStatus())
-				}
+			if !proto.Equal(tt.out, response) {
+				t.Error("response: expected", tt.out, "received", response)
 			}
 
 			if er, ok := status.FromError(err); ok {
@@ -351,13 +335,8 @@ func Test_GetInterface(t *testing.T) {
 
 			request := &pb.GetInterfaceRequest{Name: tt.in}
 			response, err := client.GetInterface(ctx, request)
-			if response != nil {
-				// if !reflect.DeepEqual(response, tt.out) {
-				mtt, _ := proto.Marshal(tt.out)
-				mResponse, _ := proto.Marshal(response)
-				if !bytes.Equal(mtt, mResponse) {
-					t.Error("response: expected", tt.out, "received", response)
-				}
+			if !proto.Equal(tt.out, response) {
+				t.Error("response: expected", tt.out, "received", response)
 			}
 
 			if er, ok := status.FromError(err); ok {

--- a/pkg/evpn/svi_subnet_test.go
+++ b/pkg/evpn/svi_subnet_test.go
@@ -6,7 +6,6 @@
 package evpn
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -97,13 +96,8 @@ func Test_CreateSubnet(t *testing.T) {
 
 			request := &pb.CreateSubnetRequest{Subnet: tt.in, SubnetId: tt.id, Parent: "todo"}
 			response, err := client.CreateSubnet(ctx, request)
-			if response != nil {
-				// if !reflect.DeepEqual(response, tt.out) {
-				mtt, _ := proto.Marshal(tt.out)
-				mResponse, _ := proto.Marshal(response)
-				if !bytes.Equal(mtt, mResponse) {
-					t.Error("response: expected", tt.out, "received", response)
-				}
+			if !proto.Equal(tt.out, response) {
+				t.Error("response: expected", tt.out, "received", response)
 			}
 
 			if er, ok := status.FromError(err); ok {
@@ -279,18 +273,8 @@ func Test_UpdateSubnet(t *testing.T) {
 
 			request := &pb.UpdateSubnetRequest{Subnet: tt.in, UpdateMask: tt.mask}
 			response, err := client.UpdateSubnet(ctx, request)
-			if response != nil {
-				// Marshall the request and response, so we can just compare the contained data
-				mtt, _ := proto.Marshal(tt.out.Spec)
-				mResponse, _ := proto.Marshal(response.Spec)
-
-				// Compare the marshalled messages
-				if !bytes.Equal(mtt, mResponse) {
-					t.Error("response: expected", tt.out.GetSpec(), "received", response.GetSpec())
-				}
-				if !reflect.DeepEqual(response.Status, tt.out.Status) {
-					t.Error("response: expected", tt.out.GetStatus(), "received", response.GetStatus())
-				}
+			if !proto.Equal(tt.out, response) {
+				t.Error("response: expected", tt.out, "received", response)
 			}
 
 			if er, ok := status.FromError(err); ok {
@@ -362,13 +346,8 @@ func Test_GetSubnet(t *testing.T) {
 
 			request := &pb.GetSubnetRequest{Name: tt.in}
 			response, err := client.GetSubnet(ctx, request)
-			if response != nil {
-				// if !reflect.DeepEqual(response, tt.out) {
-				mtt, _ := proto.Marshal(tt.out)
-				mResponse, _ := proto.Marshal(response)
-				if !bytes.Equal(mtt, mResponse) {
-					t.Error("response: expected", tt.out, "received", response)
-				}
+			if !proto.Equal(tt.out, response) {
+				t.Error("response: expected", tt.out, "received", response)
 			}
 
 			if er, ok := status.FromError(err); ok {

--- a/pkg/evpn/tunnel_vxlan_test.go
+++ b/pkg/evpn/tunnel_vxlan_test.go
@@ -6,7 +6,6 @@
 package evpn
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -102,13 +101,8 @@ func Test_CreateTunnel(t *testing.T) {
 
 			request := &pb.CreateTunnelRequest{Tunnel: tt.in, TunnelId: tt.id, Parent: "todo"}
 			response, err := client.CreateTunnel(ctx, request)
-			if response != nil {
-				// if !reflect.DeepEqual(response, tt.out) {
-				mtt, _ := proto.Marshal(tt.out)
-				mResponse, _ := proto.Marshal(response)
-				if !bytes.Equal(mtt, mResponse) {
-					t.Error("response: expected", tt.out, "received", response)
-				}
+			if !proto.Equal(tt.out, response) {
+				t.Error("response: expected", tt.out, "received", response)
 			}
 
 			if er, ok := status.FromError(err); ok {
@@ -289,18 +283,8 @@ func Test_UpdateTunnel(t *testing.T) {
 
 			request := &pb.UpdateTunnelRequest{Tunnel: tt.in, UpdateMask: tt.mask}
 			response, err := client.UpdateTunnel(ctx, request)
-			if response != nil {
-				// Marshall the request and response, so we can just compare the contained data
-				mtt, _ := proto.Marshal(tt.out.Spec)
-				mResponse, _ := proto.Marshal(response.Spec)
-
-				// Compare the marshalled messages
-				if !bytes.Equal(mtt, mResponse) {
-					t.Error("response: expected", tt.out.GetSpec(), "received", response.GetSpec())
-				}
-				if !reflect.DeepEqual(response.Status, tt.out.Status) {
-					t.Error("response: expected", tt.out.GetStatus(), "received", response.GetStatus())
-				}
+			if !proto.Equal(tt.out, response) {
+				t.Error("response: expected", tt.out, "received", response)
 			}
 
 			if er, ok := status.FromError(err); ok {
@@ -372,13 +356,8 @@ func Test_GetTunnel(t *testing.T) {
 
 			request := &pb.GetTunnelRequest{Name: tt.in}
 			response, err := client.GetTunnel(ctx, request)
-			if response != nil {
-				// if !reflect.DeepEqual(response, tt.out) {
-				mtt, _ := proto.Marshal(tt.out)
-				mResponse, _ := proto.Marshal(response)
-				if !bytes.Equal(mtt, mResponse) {
-					t.Error("response: expected", tt.out, "received", response)
-				}
+			if !proto.Equal(tt.out, response) {
+				t.Error("response: expected", tt.out, "received", response)
 			}
 
 			if er, ok := status.FromError(err); ok {

--- a/pkg/evpn/vrf_test.go
+++ b/pkg/evpn/vrf_test.go
@@ -6,7 +6,6 @@
 package evpn
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -91,13 +90,8 @@ func Test_CreateVpc(t *testing.T) {
 
 			request := &pb.CreateVpcRequest{Vpc: tt.in, VpcId: tt.id, Parent: "todo"}
 			response, err := client.CreateVpc(ctx, request)
-			if response != nil {
-				// if !reflect.DeepEqual(response, tt.out) {
-				mtt, _ := proto.Marshal(tt.out)
-				mResponse, _ := proto.Marshal(response)
-				if !bytes.Equal(mtt, mResponse) {
-					t.Error("response: expected", tt.out, "received", response)
-				}
+			if !proto.Equal(tt.out, response) {
+				t.Error("response: expected", tt.out, "received", response)
 			}
 
 			if er, ok := status.FromError(err); ok {
@@ -268,18 +262,8 @@ func Test_UpdateVpc(t *testing.T) {
 
 			request := &pb.UpdateVpcRequest{Vpc: tt.in, UpdateMask: tt.mask}
 			response, err := client.UpdateVpc(ctx, request)
-			if response != nil {
-				// Marshall the request and response, so we can just compare the contained data
-				mtt, _ := proto.Marshal(tt.out.Spec)
-				mResponse, _ := proto.Marshal(response.Spec)
-
-				// Compare the marshalled messages
-				if !bytes.Equal(mtt, mResponse) {
-					t.Error("response: expected", tt.out.GetSpec(), "received", response.GetSpec())
-				}
-				if !reflect.DeepEqual(response.Status, tt.out.Status) {
-					t.Error("response: expected", tt.out.GetStatus(), "received", response.GetStatus())
-				}
+			if !proto.Equal(tt.out, response) {
+				t.Error("response: expected", tt.out, "received", response)
 			}
 
 			if er, ok := status.FromError(err); ok {
@@ -351,13 +335,8 @@ func Test_GetVpc(t *testing.T) {
 
 			request := &pb.GetVpcRequest{Name: tt.in}
 			response, err := client.GetVpc(ctx, request)
-			if response != nil {
-				// if !reflect.DeepEqual(response, tt.out) {
-				mtt, _ := proto.Marshal(tt.out)
-				mResponse, _ := proto.Marshal(response)
-				if !bytes.Equal(mtt, mResponse) {
-					t.Error("response: expected", tt.out, "received", response)
-				}
+			if !proto.Equal(tt.out, response) {
+				t.Error("response: expected", tt.out, "received", response)
 			}
 
 			if er, ok := status.FromError(err); ok {


### PR DESCRIPTION
instead of marshal or deepequal
code reduction

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
