### PR TITLE
ci: start using mockery

### DIFF
--- a/pkg/evpn/bridge_test.go
+++ b/pkg/evpn/bridge_test.go
@@ -119,7 +119,8 @@ func Test_CreateLogicalBridge(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -206,7 +207,8 @@ func Test_DeleteLogicalBridge(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -295,7 +297,8 @@ func Test_UpdateLogicalBridge(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -374,7 +377,8 @@ func Test_GetLogicalBridge(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/pkg/evpn/port_test.go
+++ b/pkg/evpn/port_test.go
@@ -114,7 +114,8 @@ func Test_CreateBridgePort(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -201,7 +202,8 @@ func Test_DeleteBridgePort(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -291,7 +293,8 @@ func Test_UpdateBridgePort(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -370,7 +373,8 @@ func Test_GetBridgePort(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/pkg/evpn/svi_test.go
+++ b/pkg/evpn/svi_test.go
@@ -129,7 +129,8 @@ func Test_CreateSvi(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -216,7 +217,8 @@ func Test_DeleteSvi(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -307,7 +309,8 @@ func Test_UpdateSvi(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -386,7 +389,8 @@ func Test_GetSvi(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/pkg/evpn/vrf.go
+++ b/pkg/evpn/vrf.go
@@ -56,7 +56,11 @@ func (s *Server) CreateVrf(_ context.Context, in *pb.CreateVrfRequest) (*pb.Vrf,
 	}
 	// not found, so create a new one
 	vrfName := resourceID
-	tableID := uint32(1000 + math.Mod(float64(*in.Vrf.Spec.Vni), 10.0))
+	// TODO: consider choosing random table ID
+	tableID := uint32(1000)
+	if in.Vrf.Spec.Vni != nil {
+		tableID = uint32(1001 + math.Mod(float64(*in.Vrf.Spec.Vni), 10.0))
+	}
 	// Example: ip link add blue type vrf table 1000
 	vrf := &netlink.Vrf{LinkAttrs: netlink.LinkAttrs{Name: vrfName}, Table: tableID}
 	log.Printf("Creating VRF %v", vrf)

--- a/pkg/evpn/vrf_test.go
+++ b/pkg/evpn/vrf_test.go
@@ -90,7 +90,8 @@ func Test_CreateVrf(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -177,7 +178,8 @@ func Test_DeleteVrf(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -268,7 +270,8 @@ func Test_UpdateVrf(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -347,7 +350,8 @@ func Test_GetVrf(t *testing.T) {
 			// start GRPC mockup server
 			ctx := context.Background()
 			opi := NewServer()
-			opi.nLink = &mocks.Netlink{}
+			mockNetlink := mocks.NewNetlink(t)
+			opi.nLink = mockNetlink
 			conn, err := grpc.DialContext(ctx,
 				"",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),


### PR DESCRIPTION
- test: init using NewNetlink function
- test: start using mockery
- fix(vrf): handle empty Vni case
- see #130