### PR TITLE
test: prevent global test objects modification

### DIFF
--- a/pkg/evpn/bridge_test.go
+++ b/pkg/evpn/bridge_test.go
@@ -192,9 +192,11 @@ func Test_CreateLogicalBridge(t *testing.T) {
 			client := pb.NewLogicalBridgeServiceClient(conn)
 
 			if tt.exist {
-				opi.Bridges[testLogicalBridgeName] = &testLogicalBridge
+				opi.Bridges[testLogicalBridgeName] = proto.Clone(&testLogicalBridge).(*pb.LogicalBridge)
+				opi.Bridges[testLogicalBridgeName].Name = testLogicalBridgeName
 			}
 			if tt.out != nil {
+				tt.out = proto.Clone(tt.out).(*pb.LogicalBridge)
 				tt.out.Name = testLogicalBridgeName
 			}
 
@@ -323,7 +325,7 @@ func Test_DeleteLogicalBridge(t *testing.T) {
 			client := pb.NewLogicalBridgeServiceClient(conn)
 
 			fname1 := resourceIDToFullName("bridges", tt.in)
-			opi.Bridges[testLogicalBridgeName] = &testLogicalBridge
+			opi.Bridges[testLogicalBridgeName] = proto.Clone(&testLogicalBridge).(*pb.LogicalBridge)
 
 			request := &pb.DeleteLogicalBridgeRequest{Name: fname1, AllowMissing: tt.missing}
 			response, err := client.DeleteLogicalBridge(ctx, request)
@@ -412,9 +414,11 @@ func Test_UpdateLogicalBridge(t *testing.T) {
 			client := pb.NewLogicalBridgeServiceClient(conn)
 
 			if tt.exist {
-				opi.Bridges[testLogicalBridgeName] = &testLogicalBridge
+				opi.Bridges[testLogicalBridgeName] = proto.Clone(&testLogicalBridge).(*pb.LogicalBridge)
+				opi.Bridges[testLogicalBridgeName].Name = testLogicalBridgeName
 			}
 			if tt.out != nil {
+				tt.out = proto.Clone(tt.out).(*pb.LogicalBridge)
 				tt.out.Name = testLogicalBridgeName
 			}
 
@@ -490,7 +494,7 @@ func Test_GetLogicalBridge(t *testing.T) {
 			}(conn)
 			client := pb.NewLogicalBridgeServiceClient(conn)
 
-			opi.Bridges[testLogicalBridgeID] = &testLogicalBridge
+			opi.Bridges[testLogicalBridgeID] = proto.Clone(&testLogicalBridge).(*pb.LogicalBridge)
 
 			request := &pb.GetLogicalBridgeRequest{Name: tt.in}
 			response, err := client.GetLogicalBridge(ctx, request)

--- a/pkg/evpn/port_test.go
+++ b/pkg/evpn/port_test.go
@@ -141,9 +141,11 @@ func Test_CreateBridgePort(t *testing.T) {
 			client := pb.NewBridgePortServiceClient(conn)
 
 			if tt.exist {
-				opi.Ports[testBridgePortName] = &testBridgePort
+				opi.Ports[testBridgePortName] = proto.Clone(&testBridgePort).(*pb.BridgePort)
+				opi.Ports[testBridgePortName].Name = testBridgePortName
 			}
 			if tt.out != nil {
+				tt.out = proto.Clone(tt.out).(*pb.BridgePort)
 				tt.out.Name = testBridgePortName
 			}
 
@@ -233,7 +235,7 @@ func Test_DeleteBridgePort(t *testing.T) {
 			client := pb.NewBridgePortServiceClient(conn)
 
 			fname1 := resourceIDToFullName("ports", tt.in)
-			opi.Ports[testBridgePortName] = &testBridgePort
+			opi.Ports[testBridgePortName] = proto.Clone(&testBridgePort).(*pb.BridgePort)
 
 			request := &pb.DeleteBridgePortRequest{Name: fname1, AllowMissing: tt.missing}
 			response, err := client.DeleteBridgePort(ctx, request)
@@ -323,9 +325,11 @@ func Test_UpdateBridgePort(t *testing.T) {
 			client := pb.NewBridgePortServiceClient(conn)
 
 			if tt.exist {
-				opi.Ports[testBridgePortName] = &testBridgePort
+				opi.Ports[testBridgePortName] = proto.Clone(&testBridgePort).(*pb.BridgePort)
+				opi.Ports[testBridgePortName].Name = testBridgePortName
 			}
 			if tt.out != nil {
+				tt.out = proto.Clone(tt.out).(*pb.BridgePort)
 				tt.out.Name = testBridgePortName
 			}
 
@@ -401,7 +405,7 @@ func Test_GetBridgePort(t *testing.T) {
 			}(conn)
 			client := pb.NewBridgePortServiceClient(conn)
 
-			opi.Ports[testBridgePortID] = &testBridgePort
+			opi.Ports[testBridgePortID] = proto.Clone(&testBridgePort).(*pb.BridgePort)
 
 			request := &pb.GetBridgePortRequest{Name: tt.in}
 			response, err := client.GetBridgePort(ctx, request)

--- a/pkg/evpn/svi_test.go
+++ b/pkg/evpn/svi_test.go
@@ -243,13 +243,15 @@ func Test_CreateSvi(t *testing.T) {
 			client := pb.NewSviServiceClient(conn)
 
 			if tt.exist {
-				opi.Svis[testSviName] = &testSvi
+				opi.Svis[testSviName] = proto.Clone(&testSvi).(*pb.Svi)
+				opi.Svis[testSviName].Name = testSviName
 			}
 			if tt.out != nil {
+				tt.out = proto.Clone(tt.out).(*pb.Svi)
 				tt.out.Name = testSviName
 			}
-			opi.Vrfs[testVrfName] = &testVrf
-			opi.Bridges[testLogicalBridgeName] = &testLogicalBridge
+			opi.Vrfs[testVrfName] = proto.Clone(&testVrf).(*pb.Vrf)
+			opi.Bridges[testLogicalBridgeName] = proto.Clone(&testLogicalBridge).(*pb.LogicalBridge)
 
 			// TODO: refactor this mocking
 			if strings.Contains(name, "failed LinkByName") {
@@ -365,7 +367,7 @@ func Test_DeleteSvi(t *testing.T) {
 			client := pb.NewSviServiceClient(conn)
 
 			fname1 := resourceIDToFullName("svis", tt.in)
-			opi.Svis[testSviName] = &testSvi
+			opi.Svis[testSviName] = proto.Clone(&testSvi).(*pb.Svi)
 
 			request := &pb.DeleteSviRequest{Name: fname1, AllowMissing: tt.missing}
 			response, err := client.DeleteSvi(ctx, request)
@@ -456,9 +458,11 @@ func Test_UpdateSvi(t *testing.T) {
 			client := pb.NewSviServiceClient(conn)
 
 			if tt.exist {
-				opi.Svis[testSviName] = &testSvi
+				opi.Svis[testSviName] = proto.Clone(&testSvi).(*pb.Svi)
+				opi.Svis[testSviName].Name = testSviName
 			}
 			if tt.out != nil {
+				tt.out = proto.Clone(tt.out).(*pb.Svi)
 				tt.out.Name = testSviName
 			}
 
@@ -534,7 +538,7 @@ func Test_GetSvi(t *testing.T) {
 			}(conn)
 			client := pb.NewSviServiceClient(conn)
 
-			opi.Svis[testSviID] = &testSvi
+			opi.Svis[testSviName] = proto.Clone(&testSvi).(*pb.Svi)
 
 			request := &pb.GetSviRequest{Name: tt.in}
 			response, err := client.GetSvi(ctx, request)

--- a/pkg/evpn/vrf_test.go
+++ b/pkg/evpn/vrf_test.go
@@ -174,9 +174,11 @@ func Test_CreateVrf(t *testing.T) {
 			client := pb.NewVrfServiceClient(conn)
 
 			if tt.exist {
-				opi.Vrfs[testVrfName] = &testVrf
+				opi.Vrfs[testVrfName] = proto.Clone(&testVrf).(*pb.Vrf)
+				opi.Vrfs[testVrfName].Name = testVrfName
 			}
 			if tt.out != nil {
+				tt.out = proto.Clone(tt.out).(*pb.Vrf)
 				tt.out.Name = testVrfName
 			}
 
@@ -296,7 +298,7 @@ func Test_DeleteVrf(t *testing.T) {
 			client := pb.NewVrfServiceClient(conn)
 
 			fname1 := resourceIDToFullName("vrfs", tt.in)
-			opi.Vrfs[testVrfName] = &testVrf
+			opi.Vrfs[testVrfName] = proto.Clone(&testVrf).(*pb.Vrf)
 
 			request := &pb.DeleteVrfRequest{Name: fname1, AllowMissing: tt.missing}
 			response, err := client.DeleteVrf(ctx, request)
@@ -387,9 +389,11 @@ func Test_UpdateVrf(t *testing.T) {
 			client := pb.NewVrfServiceClient(conn)
 
 			if tt.exist {
-				opi.Vrfs[testVrfName] = &testVrf
+				opi.Vrfs[testVrfName] = proto.Clone(&testVrf).(*pb.Vrf)
+				opi.Vrfs[testVrfName].Name = testVrfName
 			}
 			if tt.out != nil {
+				tt.out = proto.Clone(tt.out).(*pb.Vrf)
 				tt.out.Name = testVrfName
 			}
 
@@ -465,7 +469,7 @@ func Test_GetVrf(t *testing.T) {
 			}(conn)
 			client := pb.NewVrfServiceClient(conn)
 
-			opi.Vrfs[testVrfID] = &testVrf
+			opi.Vrfs[testVrfName] = proto.Clone(&testVrf).(*pb.Vrf)
 
 			request := &pb.GetVrfRequest{Name: tt.in}
 			response, err := client.GetVrf(ctx, request)


### PR DESCRIPTION
This is done by creating object copy.
This reduces test dependencies.

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
