### PR TITLE
fix(evpn-bridge): make tracer optional

### DIFF
--- a/pkg/utils/frr.go
+++ b/pkg/utils/frr.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 const (
@@ -64,13 +65,18 @@ type FrrWrapper struct {
 
 // NewFrrWrapper creates initialized instance of FrrWrapper with default address
 func NewFrrWrapper() *FrrWrapper {
-	return NewFrrWrapperWithArgs(defaultAddress)
+	return NewFrrWrapperWithArgs(defaultAddress, true)
 }
 
 // NewFrrWrapperWithArgs creates initialized instance of FrrWrapper
-func NewFrrWrapperWithArgs(address string) *FrrWrapper {
-	// default tracer name is good for now
-	return &FrrWrapper{address: address, tracer: otel.Tracer("")}
+func NewFrrWrapperWithArgs(address string, enableTracer bool) *FrrWrapper {
+	frrWrapper := &FrrWrapper{address: address}
+	frrWrapper.tracer = noop.NewTracerProvider().Tracer("")
+	if enableTracer {
+		// default tracer name is good for now
+		frrWrapper.tracer = otel.Tracer("")
+	}
+	return frrWrapper
 }
 
 // build time check that struct implements interface

--- a/pkg/utils/netlink.go
+++ b/pkg/utils/netlink.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 // Netlink represents limited subset of functions from netlink package
@@ -73,7 +74,18 @@ type NetlinkWrapper struct {
 
 // NewNetlinkWrapper creates initialized instance of NetlinkWrapper
 func NewNetlinkWrapper() *NetlinkWrapper {
-	return &NetlinkWrapper{tracer: otel.Tracer("")}
+	return NewNetlinkWrapperWithArgs(true)
+}
+
+// NewNetlinkWrapperWithArgs creates initialized instance of NetlinkWrapper
+// based on passing arguments
+func NewNetlinkWrapperWithArgs(enableTracer bool) *NetlinkWrapper {
+	netlinkWrapper := &NetlinkWrapper{}
+	netlinkWrapper.tracer = noop.NewTracerProvider().Tracer("")
+	if enableTracer {
+		netlinkWrapper.tracer = otel.Tracer("")
+	}
+	return netlinkWrapper
 }
 
 // build time check that struct implements interface


### PR DESCRIPTION
Make tracer optional so we can import the netlinkWrapper library from evpn-gw-cni. 

More info here: https://github.com/opiproject/opi-gateway-evpn-cni/pull/14#discussion_r1515365216