### PR TITLE
fix(evpn-bridge): fix incorrect subnet in CI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -488,4 +488,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 40.40.40.41/28
+        - subnet: 40.40.40.0/24


### PR DESCRIPTION
Due to an incorrect subnet in docker compose file the CI was failing