### PR TITLE
Introduce replaydb feature

### DIFF
--- a/pkg/frr/frr.go
+++ b/pkg/frr/frr.go
@@ -217,7 +217,7 @@ func handlesvi(objectData *eventbus.ObjectData) {
 		log.Printf("%+v\n", comp)
 
 		// Checking the timer to decide if we need to replay or not
-		comp.Replay = utils.CheckReplayThreshold(comp.Timer, replayThreshold)
+		comp.CheckReplayThreshold(replayThreshold)
 
 		err := infradb.UpdateSviStatus(objectData.Name, objectData.ResourceVersion, objectData.NotificationID, nil, comp)
 		if err != nil {
@@ -240,7 +240,7 @@ func handlesvi(objectData *eventbus.ObjectData) {
 		log.Printf("%+v\n", comp)
 
 		// Checking the timer to decide if we need to replay or not
-		comp.Replay = utils.CheckReplayThreshold(comp.Timer, replayThreshold)
+		comp.CheckReplayThreshold(replayThreshold)
 
 		err := infradb.UpdateSviStatus(objectData.Name, objectData.ResourceVersion, objectData.NotificationID, nil, comp)
 		if err != nil {
@@ -318,7 +318,7 @@ func handlevrf(objectData *eventbus.ObjectData) {
 		log.Printf("%+v\n", comp)
 
 		// Checking the timer to decide if we need to replay or not
-		comp.Replay = utils.CheckReplayThreshold(comp.Timer, replayThreshold)
+		comp.CheckReplayThreshold(replayThreshold)
 
 		err := infradb.UpdateVrfStatus(objectData.Name, objectData.ResourceVersion, objectData.NotificationID, nil, comp)
 		if err != nil {
@@ -341,7 +341,7 @@ func handlevrf(objectData *eventbus.ObjectData) {
 		log.Printf("%+v\n", comp)
 
 		// Checking the timer to decide if we need to replay or not
-		comp.Replay = utils.CheckReplayThreshold(comp.Timer, replayThreshold)
+		comp.CheckReplayThreshold(replayThreshold)
 
 		err := infradb.UpdateVrfStatus(objectData.Name, objectData.ResourceVersion, objectData.NotificationID, nil, comp)
 		if err != nil {

--- a/pkg/frr/frr.go
+++ b/pkg/frr/frr.go
@@ -200,9 +200,7 @@ func handlesvi(objectData *eventbus.ObjectData) {
 		log.Printf("%+v\n", comp)
 
 		// Checking the timer to decide if we need to replay or not
-		if comp.Timer > replayThreshold {
-			comp.Replay = true
-		}
+		comp.Replay = utils.CheckReplayThreshold(comp.Timer, replayThreshold)
 
 		err := infradb.UpdateSviStatus(objectData.Name, objectData.ResourceVersion, objectData.NotificationID, nil, comp)
 		if err != nil {
@@ -225,9 +223,7 @@ func handlesvi(objectData *eventbus.ObjectData) {
 		log.Printf("%+v\n", comp)
 
 		// Checking the timer to decide if we need to replay or not
-		if comp.Timer > replayThreshold {
-			comp.Replay = true
-		}
+		comp.Replay = utils.CheckReplayThreshold(comp.Timer, replayThreshold)
 
 		err := infradb.UpdateSviStatus(objectData.Name, objectData.ResourceVersion, objectData.NotificationID, nil, comp)
 		if err != nil {
@@ -305,9 +301,7 @@ func handlevrf(objectData *eventbus.ObjectData) {
 		log.Printf("%+v\n", comp)
 
 		// Checking the timer to decide if we need to replay or not
-		if comp.Timer > replayThreshold {
-			comp.Replay = true
-		}
+		comp.Replay = utils.CheckReplayThreshold(comp.Timer, replayThreshold)
 
 		err := infradb.UpdateVrfStatus(objectData.Name, objectData.ResourceVersion, objectData.NotificationID, nil, comp)
 		if err != nil {
@@ -330,9 +324,7 @@ func handlevrf(objectData *eventbus.ObjectData) {
 		log.Printf("%+v\n", comp)
 
 		// Checking the timer to decide if we need to replay or not
-		if comp.Timer > replayThreshold {
-			comp.Replay = true
-		}
+		comp.Replay = utils.CheckReplayThreshold(comp.Timer, replayThreshold)
 
 		err := infradb.UpdateVrfStatus(objectData.Name, objectData.ResourceVersion, objectData.NotificationID, nil, comp)
 		if err != nil {

--- a/pkg/infradb/common/common.go
+++ b/pkg/infradb/common/common.go
@@ -34,6 +34,8 @@ type Component struct {
 	// Free format json string
 	Details string
 	Timer   time.Duration
+	// Replay is used when the module wants to trigger replay action
+	Replay bool
 }
 
 func ip4ToInt(ip net.IP) uint32 {

--- a/pkg/infradb/common/common.go
+++ b/pkg/infradb/common/common.go
@@ -38,6 +38,11 @@ type Component struct {
 	Replay bool
 }
 
+// CheckReplayThreshold checks if the replay threshold has been exceeded
+func (c *Component) CheckReplayThreshold(replayThreshold time.Duration) {
+	c.Replay = (c.Timer > replayThreshold)
+}
+
 func ip4ToInt(ip net.IP) uint32 {
 	if !reflect.ValueOf(ip).IsZero() {
 		return uint32(ip[0])<<24 | uint32(ip[1])<<16 | uint32(ip[2])<<8 | uint32(ip[3])

--- a/pkg/infradb/replay.go
+++ b/pkg/infradb/replay.go
@@ -85,37 +85,19 @@ func startReplayProcedure(componentName string) {
 // which are related to the component that called the replay.
 func getObjectTypesToReplay(componentName string) []string {
 	objectTypesToReplay := []string{}
+	typesAndSubs := make(map[string][]*eventbus.Subscriber)
 
-	bpSubs := eventbus.EBus.GetSubscribers("bridge-port")
-	sviSubs := eventbus.EBus.GetSubscribers("svi")
-	lbSubs := eventbus.EBus.GetSubscribers("logical-bridge")
-	vrfSubs := eventbus.EBus.GetSubscribers("vrf")
+	typesAndSubs["bridge-port"] = eventbus.EBus.GetSubscribers("bridge-port")
+	typesAndSubs["svi"] = eventbus.EBus.GetSubscribers("svi")
+	typesAndSubs["logical-bridge"] = eventbus.EBus.GetSubscribers("logical-bridge")
+	typesAndSubs["vrf"] = eventbus.EBus.GetSubscribers("vrf")
 
-	for _, vrfSub := range vrfSubs {
-		if vrfSub.Name == componentName {
-			objectTypesToReplay = append(objectTypesToReplay, "vrf")
-			break
-		}
-	}
-
-	for _, lbSub := range lbSubs {
-		if lbSub.Name == componentName {
-			objectTypesToReplay = append(objectTypesToReplay, "logical-bridge")
-			break
-		}
-	}
-
-	for _, sviSub := range sviSubs {
-		if sviSub.Name == componentName {
-			objectTypesToReplay = append(objectTypesToReplay, "svi")
-			break
-		}
-	}
-
-	for _, bpSub := range bpSubs {
-		if bpSub.Name == componentName {
-			objectTypesToReplay = append(objectTypesToReplay, "bridge-port")
-			break
+	for objType, subs := range typesAndSubs {
+		for _, sub := range subs {
+			if sub.Name == componentName {
+				objectTypesToReplay = append(objectTypesToReplay, objType)
+				break
+			}
 		}
 	}
 

--- a/pkg/infradb/replay.go
+++ b/pkg/infradb/replay.go
@@ -22,6 +22,7 @@ func startReplayProcedure(componentName string) {
 
 	defer func() {
 		if deferErr != nil {
+			globalLock.Unlock()
 			log.Println("startReplayProcedure(): The replay procedure has failed")
 			log.Println("startReplayProcedure(): unblocking the TaskManager to continue")
 			taskmanager.TaskMan.ReplayFinished()
@@ -64,11 +65,9 @@ func startReplayProcedure(componentName string) {
 
 	objectTypesToReplay := getObjectTypesToReplay(componentName)
 
-	objectsToReplay, subsForReplay, err := gatherObjectsAndSubsToReplay(componentName, objectTypesToReplay)
-
-	if err != nil {
-		log.Printf("startReplayProcedure(): Error %+v\n", err)
-		deferErr = err
+	objectsToReplay, subsForReplay, deferErr := gatherObjectsAndSubsToReplay(componentName, objectTypesToReplay)
+	if deferErr != nil {
+		log.Printf("startReplayProcedure(): Error %+v\n", deferErr)
 		return
 	}
 

--- a/pkg/infradb/subscriberframework/actionbus/actionbus.go
+++ b/pkg/infradb/subscriberframework/actionbus/actionbus.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2023-2024 Intel Corporation, or its subsidiaries.
+// Copyright (c) 2024 Ericsson AB
+
+// Package actionbus holds implementation for subscribing and receiving actions
+package actionbus
+
+import (
+	"fmt"
+	"log"
+	"sync"
+)
+
+// ABus holds the ActionBus object
+var ABus = NewActionBus()
+
+// ActionBus holds the action bus info
+type ActionBus struct {
+	subscribers    map[string][]*Subscriber
+	actionHandlers map[string]ActionHandler
+	subscriberL    sync.RWMutex
+	mutex          sync.RWMutex
+}
+
+// Subscriber holds the info for each subscriber
+type Subscriber struct {
+	Name string
+	Ch   chan interface{}
+	Quit chan bool
+}
+
+// ActionHandler handles the action requests that arrive
+type ActionHandler interface {
+	HandleAction(string, *ActionData)
+}
+
+// ActionData holds the data for each action
+type ActionData struct {
+	ErrCh chan error
+}
+
+// StartSubscriber will be called by the modules to initialize and start listening for actions
+func (a *ActionBus) StartSubscriber(moduleName, actionType string, actionHandler ActionHandler) {
+	if !a.subscriberExist(actionType, moduleName) {
+		subscriber := a.Subscribe(moduleName, actionType, actionHandler)
+
+		go func() {
+			for {
+				select {
+				case action := <-subscriber.Ch:
+					log.Printf("\nSubscriber %s for %s received \n", moduleName, actionType)
+
+					handlerKey := moduleName + "." + actionType
+					if handler, ok := a.actionHandlers[handlerKey]; ok {
+						if actionData, ok := action.(*ActionData); ok {
+							handler.HandleAction(actionType, actionData)
+						} else {
+							log.Println("error: unexpected action type")
+						}
+					} else {
+						log.Println("error: no action handler found")
+					}
+				case <-subscriber.Quit:
+					close(subscriber.Ch)
+					return
+				}
+			}
+		}()
+	}
+}
+
+// NewActionBus initializes an ActionBus object
+func NewActionBus() *ActionBus {
+	return &ActionBus{
+		subscribers:    make(map[string][]*Subscriber),
+		actionHandlers: make(map[string]ActionHandler),
+	}
+}
+
+// NewActionData initializes an ActionData object
+func NewActionData() *ActionData {
+	return &ActionData{
+		ErrCh: make(chan error),
+	}
+}
+
+// Subscribe api provides registration of a subscriber to the given action
+func (a *ActionBus) Subscribe(moduleName, actionType string, actionHandler ActionHandler) *Subscriber {
+	a.subscriberL.Lock()
+	defer a.subscriberL.Unlock()
+
+	subscriber := &Subscriber{
+		Name: moduleName,
+		Ch:   make(chan interface{}),
+		Quit: make(chan bool),
+	}
+
+	a.subscribers[actionType] = append(a.subscribers[actionType], subscriber)
+	a.actionHandlers[moduleName+"."+actionType] = actionHandler
+
+	log.Printf("Subscriber %s registered for action %s\n", moduleName, actionType)
+	return subscriber
+}
+
+// GetSubscribers api is used to fetch the list of subscribers registered with given actionType
+func (a *ActionBus) GetSubscribers(actionType string) []*Subscriber {
+	a.mutex.RLock()
+	defer a.mutex.RUnlock()
+
+	return a.subscribers[actionType]
+}
+
+// Publish api notifies the subscribers with certain actionType
+func (a *ActionBus) Publish(actionData *ActionData, subscriber *Subscriber) error {
+	var err error
+
+	select {
+	case subscriber.Ch <- actionData:
+		log.Printf("Publish(): Notification is sent to subscriber %s\n", subscriber.Name)
+	default:
+		err = fmt.Errorf("channel for subscriber %s is busy", subscriber.Name)
+	}
+	return err
+}
+
+func (a *ActionBus) subscriberExist(actionType string, moduleName string) bool {
+	subList := a.GetSubscribers(actionType)
+	if len(subList) != 0 {
+		for _, s := range subList {
+			if s.Name == moduleName {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/infradb/subscriberframework/actionbus/actionbus.go
+++ b/pkg/infradb/subscriberframework/actionbus/actionbus.go
@@ -51,7 +51,7 @@ func (a *ActionBus) StartSubscriber(moduleName, actionType string, actionHandler
 				case action := <-subscriber.Ch:
 					log.Printf("\nSubscriber %s for %s received \n", moduleName, actionType)
 
-					handlerKey := utils.ConcatenateModuleNameWithType(moduleName, actionType)
+					handlerKey := utils.ComposeHandlerName(moduleName, actionType)
 					if handler, ok := a.actionHandlers[handlerKey]; ok {
 						if actionData, ok := action.(*ActionData); ok {
 							handler.HandleAction(actionType, actionData)
@@ -98,7 +98,7 @@ func (a *ActionBus) Subscribe(moduleName, actionType string, actionHandler Actio
 
 	a.subscribers[actionType] = append(a.subscribers[actionType], subscriber)
 
-	handlerKey := utils.ConcatenateModuleNameWithType(moduleName, actionType)
+	handlerKey := utils.ComposeHandlerName(moduleName, actionType)
 	a.actionHandlers[handlerKey] = actionHandler
 
 	log.Printf("Subscriber %s registered for action %s\n", moduleName, actionType)
@@ -107,8 +107,8 @@ func (a *ActionBus) Subscribe(moduleName, actionType string, actionHandler Actio
 
 // GetSubscribers api is used to fetch the list of subscribers registered with given actionType
 func (a *ActionBus) GetSubscribers(actionType string) []*Subscriber {
-	a.subscriberL.Lock()
-	defer a.subscriberL.Unlock()
+	a.subscriberL.RLock()
+	defer a.subscriberL.RUnlock()
 
 	return a.subscribers[actionType]
 }

--- a/pkg/infradb/subscriberframework/eventbus/eventbus.go
+++ b/pkg/infradb/subscriberframework/eventbus/eventbus.go
@@ -56,7 +56,7 @@ func (e *EventBus) StartSubscriber(moduleName, eventType string, priority int, e
 				case event := <-subscriber.Ch:
 					log.Printf("\nSubscriber %s for %s received \n", moduleName, eventType)
 
-					handlerKey := utils.ConcatenateModuleNameWithType(moduleName, eventType)
+					handlerKey := utils.ComposeHandlerName(moduleName, eventType)
 					if handler, ok := e.eventHandlers[handlerKey]; ok {
 						if objectData, ok := event.(*ObjectData); ok {
 							handler.HandleEvent(eventType, objectData)
@@ -99,7 +99,7 @@ func (e *EventBus) Subscribe(moduleName, eventType string, priority int, eventHa
 
 	e.subscribers[eventType] = append(e.subscribers[eventType], subscriber)
 
-	handlerKey := utils.ConcatenateModuleNameWithType(moduleName, eventType)
+	handlerKey := utils.ComposeHandlerName(moduleName, eventType)
 	e.eventHandlers[handlerKey] = eventHandler
 
 	// Sort subscribers based on priority
@@ -142,7 +142,7 @@ func (e *EventBus) UnsubscribeModule(moduleName string) bool {
 					sub.Quit <- true
 					e.subscribers[eventName] = append(subs[:i], subs[i+1:]...)
 
-					handlerKey := utils.ConcatenateModuleNameWithType(moduleName, eventName)
+					handlerKey := utils.ComposeHandlerName(moduleName, eventName)
 					e.eventHandlers[handlerKey] = nil
 					log.Printf("\n Module %s is unsubscribed for event %s", sub.Name, eventName)
 				}

--- a/pkg/infradb/taskmanager/taskmanager.go
+++ b/pkg/infradb/taskmanager/taskmanager.go
@@ -112,6 +112,8 @@ func (t *TaskManager) ReplayFinished() {
 }
 
 // processTasks processes the task
+//
+//gocognit:ignore
 func (t *TaskManager) processTasks() {
 	var taskStatus *TaskStatus
 

--- a/pkg/infradb/utils.go
+++ b/pkg/infradb/utils.go
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2023-2024 Intel Corporation, or its subsidiaries.
+// Copyright (c) 2024 Ericsson AB
+
+// Package infradb exposes the interface for the manipulation of the api objects
+package infradb
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/opiproject/opi-evpn-bridge/pkg/infradb/subscriberframework/actionbus"
+	"github.com/opiproject/opi-evpn-bridge/pkg/infradb/subscriberframework/eventbus"
+	"github.com/opiproject/opi-evpn-bridge/pkg/infradb/taskmanager"
+)
+
+func startReplayProcedure(componentName string) {
+	globalLock.Lock()
+
+	var deferErr error
+	var preSubscriber *actionbus.Subscriber
+
+	defer func() {
+		if deferErr != nil {
+			log.Println("startReplayProcedure(): The replay procedure has failed")
+			log.Println("startReplayProcedure(): unblocking the TaskManager to continue")
+			taskmanager.TaskMan.ReplayFinished()
+		}
+	}()
+
+	preSubscribers := actionbus.ABus.GetSubscribers("preReplay")
+
+	for _, preSub := range preSubscribers {
+		if preSub.Name == componentName {
+			preSubscriber = preSub
+			break
+		}
+	}
+
+	if preSubscriber == nil {
+		deferErr = fmt.Errorf("no pre-replay subscriber for %s", componentName)
+		log.Printf("startReplayProcedure(): Error %+v\n", deferErr)
+		return
+	}
+
+	// Notify the preReplay subscriber
+	actionData := actionbus.NewActionData()
+	deferErr = actionbus.ABus.Publish(actionData, preSubscriber)
+	if deferErr != nil {
+		log.Printf("startReplayProcedure(): Error %+v\n", deferErr)
+		return
+	}
+
+	// Waiting for the pre-replay procedure to finish
+	deferErr = <-actionData.ErrCh
+	close(actionData.ErrCh)
+
+	if deferErr != nil {
+		log.Printf("startReplayProcedure(): Error %+v\n", deferErr)
+		return
+	}
+
+	log.Printf("startReplayProcedure(): Component %s has successfully executed pre-replay steps", componentName)
+
+	objectTypesToReplay := getObjectTypesToReplay(componentName)
+
+	objectsToReplay, subsForReplay, err := gatherObjectsAndSubsToReplay(componentName, objectTypesToReplay)
+
+	if err != nil {
+		log.Printf("startReplayProcedure(): Error %+v\n", err)
+		deferErr = err
+		return
+	}
+
+	// Releasing the lock as all the operations in the DB has finished
+	globalLock.Unlock()
+
+	// Notify task manager to continue processing tasks as
+	// the replay of objects in the DB has finished
+	taskmanager.TaskMan.ReplayFinished()
+
+	createReplayTasks(objectsToReplay, subsForReplay)
+}
+
+// getObjectTypesToReplay collects all the types of object to be replayed
+// which are related to the component that called the replay.
+func getObjectTypesToReplay(componentName string) []string {
+	objectTypesToReplay := []string{}
+
+	bpSubs := eventbus.EBus.GetSubscribers("bridge-port")
+	sviSubs := eventbus.EBus.GetSubscribers("svi")
+	lbSubs := eventbus.EBus.GetSubscribers("logical-bridge")
+	vrfSubs := eventbus.EBus.GetSubscribers("vrf")
+
+	for _, vrfSub := range vrfSubs {
+		if vrfSub.Name == componentName {
+			objectTypesToReplay = append(objectTypesToReplay, "vrf")
+			break
+		}
+	}
+
+	for _, lbSub := range lbSubs {
+		if lbSub.Name == componentName {
+			objectTypesToReplay = append(objectTypesToReplay, "logical-bridge")
+			break
+		}
+	}
+
+	for _, sviSub := range sviSubs {
+		if sviSub.Name == componentName {
+			objectTypesToReplay = append(objectTypesToReplay, "svi")
+			break
+		}
+	}
+
+	for _, bpSub := range bpSubs {
+		if bpSub.Name == componentName {
+			objectTypesToReplay = append(objectTypesToReplay, "bridge-port")
+			break
+		}
+	}
+
+	return objectTypesToReplay
+}
+
+// nolint: funlen, gocognit
+func gatherObjectsAndSubsToReplay(componentName string, objectTypesToReplay []string) ([]interface{}, [][]*eventbus.Subscriber, error) {
+	objectsToReplay := []interface{}{}
+	subsForReplay := [][]*eventbus.Subscriber{}
+
+	bpSubs := eventbus.EBus.GetSubscribers("bridge-port")
+	sviSubs := eventbus.EBus.GetSubscribers("svi")
+	lbSubs := eventbus.EBus.GetSubscribers("logical-bridge")
+	vrfSubs := eventbus.EBus.GetSubscribers("vrf")
+
+	for _, objType := range objectTypesToReplay {
+		switch objType {
+		case "vrf":
+			vrfsMap := make(map[string]bool)
+			found, err := infradb.client.Get("vrfs", &vrfsMap)
+
+			if err != nil {
+				return nil, nil, err
+			}
+
+			if !found {
+				log.Println("gatherObjectsAndSubsToReplay(): No VRFs have been found")
+				continue
+			}
+
+			for key := range vrfsMap {
+				vrf := &Vrf{}
+				found, err := infradb.client.Get(key, vrf)
+				if err != nil {
+					return nil, nil, err
+				}
+
+				// Dimitris: Do we need to just continue here or throw error and stop ?
+				if !found {
+					return nil, nil, ErrKeyNotFound
+				}
+
+				// tempSubs holds the subscribers list to be contacted for every VRF object each time
+				// for replay
+				tempSubs := vrf.prepareObjectsForReplay(componentName, vrfSubs)
+
+				err = infradb.client.Set(vrf.Name, vrf)
+				if err != nil {
+					return nil, nil, err
+				}
+
+				subsForReplay = append(subsForReplay, tempSubs)
+				objectsToReplay = append(objectsToReplay, vrf)
+			}
+		case "logical-bridge":
+			lbsMap := make(map[string]bool)
+			found, err := infradb.client.Get("lbs", &lbsMap)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			if !found {
+				log.Println("gatherObjectsAndSubsToReplay(): No Logical Bridges have been found")
+				continue
+			}
+			for key := range lbsMap {
+				lb := &LogicalBridge{}
+				found, err := infradb.client.Get(key, lb)
+				if err != nil {
+					return nil, nil, err
+				}
+
+				if !found {
+					return nil, nil, ErrKeyNotFound
+				}
+
+				// tempSubs holds the subscribers list to be contacted for every VRF object each time
+				// for replay
+				tempSubs := lb.prepareObjectsForReplay(componentName, lbSubs)
+
+				err = infradb.client.Set(lb.Name, lb)
+				if err != nil {
+					return nil, nil, err
+				}
+				subsForReplay = append(subsForReplay, tempSubs)
+				objectsToReplay = append(objectsToReplay, lb)
+			}
+		case "svi":
+			svisMap := make(map[string]bool)
+			found, err := infradb.client.Get("svis", &svisMap)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			if !found {
+				log.Println("gatherObjectsAndSubsToReplay(): No SVIs have been found")
+				continue
+			}
+			for key := range svisMap {
+				svi := &Svi{}
+				found, err := infradb.client.Get(key, svi)
+				if err != nil {
+					return nil, nil, err
+				}
+
+				if !found {
+					return nil, nil, ErrKeyNotFound
+				}
+
+				// tempSubs holds the subscribers list to be contacted for every VRF object each time
+				// for replay
+				tempSubs := svi.prepareObjectsForReplay(componentName, sviSubs)
+
+				err = infradb.client.Set(svi.Name, svi)
+				if err != nil {
+					return nil, nil, err
+				}
+				subsForReplay = append(subsForReplay, tempSubs)
+				objectsToReplay = append(objectsToReplay, svi)
+			}
+		case "bp":
+			bpsMap := make(map[string]bool)
+			found, err := infradb.client.Get("bps", &bpsMap)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			if !found {
+				log.Println("gatherObjectsAndSubsToReplay(): No Bridge Ports have been found")
+				continue
+			}
+			for key := range bpsMap {
+				bp := &BridgePort{}
+				found, err := infradb.client.Get(key, bp)
+				if err != nil {
+					return nil, nil, err
+				}
+
+				if !found {
+					return nil, nil, ErrKeyNotFound
+				}
+
+				// tempSubs holds the subscribers list to be contacted for every VRF object each time
+				// for replay
+				tempSubs := bp.prepareObjectsForReplay(componentName, bpSubs)
+
+				err = infradb.client.Set(bp.Name, bp)
+				if err != nil {
+					return nil, nil, err
+				}
+				subsForReplay = append(subsForReplay, tempSubs)
+				objectsToReplay = append(objectsToReplay, bp)
+			}
+		}
+	}
+
+	return objectsToReplay, subsForReplay, nil
+}
+
+// createReplayTasks create new tasks for the realization of the new replay objects intents
+func createReplayTasks(objectsToReplay []interface{}, subsForReplay [][]*eventbus.Subscriber) {
+	for i, obj := range objectsToReplay {
+		switch tempObj := obj.(type) {
+		case *Vrf:
+			taskmanager.TaskMan.CreateTask(tempObj.Name, "vrf", tempObj.ResourceVersion, subsForReplay[i])
+		case *LogicalBridge:
+			taskmanager.TaskMan.CreateTask(tempObj.Name, "logical-bridge", tempObj.ResourceVersion, subsForReplay[i])
+		case *Svi:
+			taskmanager.TaskMan.CreateTask(tempObj.Name, "svi", tempObj.ResourceVersion, subsForReplay[i])
+		case *BridgePort:
+			taskmanager.TaskMan.CreateTask(tempObj.Name, "bridge-port", tempObj.ResourceVersion, subsForReplay[i])
+		}
+	}
+}

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os/exec"
 	"regexp"
+	"time"
 
 	"github.com/vishvananda/netlink"
 	"go.einride.tech/aip/fieldmask"
@@ -76,4 +77,14 @@ func GetIPAddress(dev string) net.IPNet {
 		}
 	}
 	return *validIps[0].IPNet
+}
+
+// CheckReplayThreshold checks if the replay threshold has been exceeded
+func CheckReplayThreshold(currentTimer, replayThreshold time.Duration) bool {
+	return (currentTimer > replayThreshold)
+}
+
+// ConcatenateModuleNameWithType this function concatenates the module name and type
+func ConcatenateModuleNameWithType(moduleName, kindOfType string) string {
+	return moduleName + "." + kindOfType
 }

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -29,10 +29,6 @@ func Run(cmd []string, _ bool) (string, int) {
 	var err error
 	out, err = exec.Command(cmd[0], cmd[1:]...).CombinedOutput() //nolint:gosec
 	if err != nil {
-		/*if flag {
-			// panic(fmt.Sprintf("Command %s': exit code %s;", out, err.Error()))
-		}
-		// fmt.Printf("Command %s': exit code %s;\n", out, err)*/
 		return "Error in running command", -1
 	}
 	output := string(out)

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"os/exec"
 	"regexp"
-	"time"
 
 	"github.com/vishvananda/netlink"
 	"go.einride.tech/aip/fieldmask"
@@ -77,11 +76,6 @@ func GetIPAddress(dev string) net.IPNet {
 		}
 	}
 	return *validIps[0].IPNet
-}
-
-// CheckReplayThreshold checks if the replay threshold has been exceeded
-func CheckReplayThreshold(currentTimer, replayThreshold time.Duration) bool {
-	return (currentTimer > replayThreshold)
 }
 
 // ComposeHandlerName this function concatenates the module name and type

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -84,7 +84,7 @@ func CheckReplayThreshold(currentTimer, replayThreshold time.Duration) bool {
 	return (currentTimer > replayThreshold)
 }
 
-// ConcatenateModuleNameWithType this function concatenates the module name and type
-func ConcatenateModuleNameWithType(moduleName, kindOfType string) string {
+// ComposeHandlerName this function concatenates the module name and type
+func ComposeHandlerName(moduleName, kindOfType string) string {
 	return moduleName + "." + kindOfType
 }

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"log"
 	"net"
+	"os/exec"
 	"regexp"
 
 	"github.com/vishvananda/netlink"
@@ -20,6 +21,22 @@ import (
 // in the update grpc request based on the provided field mask
 func ApplyMaskToStoredPbObject[T proto.Message](updateMask *fieldmaskpb.FieldMask, dst, src T) {
 	fieldmask.Update(updateMask, dst, src)
+}
+
+// Run function run the commands
+func Run(cmd []string, _ bool) (string, int) {
+	var out []byte
+	var err error
+	out, err = exec.Command(cmd[0], cmd[1:]...).CombinedOutput() //nolint:gosec
+	if err != nil {
+		/*if flag {
+			// panic(fmt.Sprintf("Command %s': exit code %s;", out, err.Error()))
+		}
+		// fmt.Printf("Command %s': exit code %s;\n", out, err)*/
+		return "Error in running command", -1
+	}
+	output := string(out)
+	return output, 0
 }
 
 // ValidateMacAddress validates if a passing MAC address


### PR DESCRIPTION
In order to move the evpn-gw-bridge into a more resilient path we have implemented the replaydb feature.

When a module (e.g. FRR module) confronts a permanent error then stops retrying and the replay procedure kicks in. The replay procedure will clean up all the system configuration (e.g. FRR daemon) that is related to the failed module and will replay the relevant objects from the database in order to bring the system configuration back on track again.

The replay feature currently is only supported for the FRR module and the FRR daemon. Support for all the modules will be added in the future