### PR TITLE
Fix channel closing issue during replay procedure

### DIFF
--- a/pkg/infradb/taskmanager/taskmanager.go
+++ b/pkg/infradb/taskmanager/taskmanager.go
@@ -114,7 +114,7 @@ func (t *TaskManager) StatusUpdated(name, objectType, resourceVersion, notificat
 
 // ReplayFinished notifies that the replay of objects has finished
 func (t *TaskManager) ReplayFinished() {
-	close(t.replayChan)
+	t.replayChan <- struct{}{}
 	log.Println("ReplayFinished(): Replay has finished.")
 }
 


### PR DESCRIPTION
A channel is used between the infradb and the task manager is order to inform taks manager that a replay procedure has been finished. By closing the channel when the replay procedure is concluded the task manager is informed this way and continues processing tasks.

The closing of the channel in this case is not the right procedure to inform the task manager. The reason is that in an event that the replay procedure is triggered again in the future infradb will try to close again the channel in order to notify the task manager and that can cause panic. 

This PR contains the fix for that.